### PR TITLE
refact: feedall

### DIFF
--- a/docs/PROJECT_FEED.md
+++ b/docs/PROJECT_FEED.md
@@ -1723,10 +1723,12 @@ Lista **TODOS os posts de TODOS os projetos de TODOS os funcionários** - ideal 
 - 📈 Estatísticas agregadas (projetos ativos, autores, fotos)
 - 📅 Ordenado do mais recente para o mais antigo (padrão)
 - ⚡ Paginação eficiente
+- 🛡️ Isolamento multi-empresa: retorna apenas posts das empresas às quais o usuário pertence
 
 #### Headers
 ```
 Authorization: Bearer {token}
+x-company-id: {empresaAtiva}   # obrigatório para manter o tenant correto
 ```
 
 #### Query Parameters
@@ -1751,26 +1753,31 @@ Authorization: Bearer {token}
 **Simples (todos os posts):**
 ```bash
 curl -X GET 'http://localhost:3000/feed/all?limit=50&offset=0' \
-  -H 'Authorization: Bearer seu-token'
+  -H 'Authorization: Bearer seu-token' \
+  -H 'x-company-id: company-123'
 ```
 
 **Com Filtros:**
 ```bash
 # Posts da última semana com fotos
 curl -X GET 'http://localhost:3000/feed/all?hasPhotos=true&startDate=2024-11-01T00:00:00Z&sortBy=photos&order=desc' \
-  -H 'Authorization: Bearer seu-token'
+  -H 'Authorization: Bearer seu-token' \
+  -H 'x-company-id: company-123'
 
 # Posts de um projeto específico
 curl -X GET 'http://localhost:3000/feed/all?projectId=project-abc-123' \
-  -H 'Authorization: Bearer seu-token'
+  -H 'Authorization: Bearer seu-token' \
+  -H 'x-company-id: company-123'
 
 # Posts de um funcionário específico
 curl -X GET 'http://localhost:3000/feed/all?userId=user-456' \
-  -H 'Authorization: Bearer seu-token'
+  -H 'Authorization: Bearer seu-token' \
+  -H 'x-company-id: company-123'
 
 # Posts do último mês ordenados por mais fotos
 curl -X GET 'http://localhost:3000/feed/all?startDate=2024-10-01T00:00:00Z&sortBy=photos&order=desc&limit=100' \
-  -H 'Authorization: Bearer seu-token'
+  -H 'Authorization: Bearer seu-token' \
+  -H 'x-company-id: company-123'
 ```
 
 #### Resposta de Sucesso (200)

--- a/src/controllers/projects/ProjectFeedController.ts
+++ b/src/controllers/projects/ProjectFeedController.ts
@@ -1,4 +1,5 @@
 import multer from "multer";
+import Jwt from "jsonwebtoken";
 import { Request, Response } from "express";
 import { prisma } from "../../utils/prisma";
 import { uploadFileToS3 } from "../../utils/S3/uploadFIleS3";
@@ -8,6 +9,70 @@ import { deleteFileFromS3 } from "../../utils/S3/deleteFileFromS3";
 const upload = multer({ dest: './public/tmp/feed' });
 
 export class ProjectFeedController {
+    /**
+     * Resolve o usuário autenticado e todas as empresas às quais ele pertence.
+     * Retorna companyIds distintos para filtrar escopo multi-tenant.
+     */
+    private async resolveUserCompanies(request: Request): Promise<{ userId?: string; companyIds: string[] }> {
+        let userId = request.headers['x-user-id'] as string | undefined;
+
+        if (!userId) {
+            const authHeader = request.headers['authorization'];
+            const token = authHeader?.startsWith('Bearer ') ? authHeader.split(' ')[1] : undefined;
+
+            if (token) {
+                try {
+                    const decoded = Jwt.verify(token, String(process.env.SECRET_JWT)) as { id?: string; userId?: string; sub?: string };
+                    userId = decoded?.id || decoded?.userId || (decoded?.sub as string | undefined);
+                } catch (error) {
+                    console.error('Erro ao decodificar token para resolver empresa do usuário:', error);
+                }
+            }
+        }
+
+        if (!userId) {
+            return { companyIds: [] };
+        }
+
+        const user = await prisma.user.findUnique({
+            where: { id: userId },
+            select: {
+                id: true,
+                company_id: true,
+                companies: {
+                    select: {
+                        companyId: true
+                    }
+                }
+            }
+        });
+
+        if (!user) {
+            return { companyIds: [] };
+        }
+
+        const requestedCompanyId = request.headers['x-company-id'] as string | undefined;
+
+        const companyIds = new Set<string>();
+        if (user.company_id) {
+            companyIds.add(user.company_id);
+        }
+        user.companies.forEach((company) => {
+            if (company.companyId) {
+                companyIds.add(company.companyId);
+            }
+        });
+
+        // Se o frontend enviar explicitamente a empresa ativa, respeitamos para evitar vazamentos entre empresas que o usuário participa
+        if (requestedCompanyId) {
+            return companyIds.has(requestedCompanyId)
+                ? { userId: user.id, companyIds: [requestedCompanyId] }
+                : { userId: user.id, companyIds: [] };
+        }
+
+        return { userId: user.id, companyIds: Array.from(companyIds) };
+    }
+
     async createPost(request: Request, response: Response) {
         const uploadMultiple = upload.array('photos', 10);
 
@@ -927,6 +992,33 @@ export class ProjectFeedController {
                 order = 'desc'
             } = request.query;
 
+            const { companyIds } = await this.resolveUserCompanies(request);
+
+            if (!companyIds || companyIds.length === 0) {
+                return response.status(403).json({
+                    error: 'Usuário não associado a nenhuma empresa. Não é possível listar o feed.'
+                });
+            }
+
+            if (projectId && typeof projectId === 'string') {
+                const project = await prisma.project.findUnique({
+                    where: { id: projectId },
+                    select: { company_id: true }
+                });
+
+                if (!project) {
+                    return response.status(404).json({
+                        error: 'Projeto não encontrado'
+                    });
+                }
+
+                if (!project.company_id || !companyIds.includes(project.company_id)) {
+                    return response.status(403).json({
+                        error: 'Você não tem permissão para acessar o feed deste projeto'
+                    });
+                }
+            }
+
             // Monta filtros dinâmicos
             const activityFilters: any = {};
 
@@ -940,6 +1032,14 @@ export class ProjectFeedController {
                     in: serviceProjects.map(sp => sp.id)
                 };
             }
+
+            // Filtro obrigatório por empresa (multi-tenant)
+            activityFilters.ServiceProject = {
+                OR: [
+                    { company_id: { in: companyIds } },
+                    { Project: { company_id: { in: companyIds } } }
+                ]
+            };
 
             // Filtro por autor
             if (userId && typeof userId === 'string') {
@@ -1163,7 +1263,8 @@ export class ProjectFeedController {
                         endDate: endDate || null,
                         hasPhotos: hasPhotos || null,
                         sortBy: sortBy,
-                        order: order
+                        order: order,
+                        companyIds: companyIds
                     },
                     statistics: {
                         totalProjects: uniqueProjects.size,
@@ -2115,4 +2216,3 @@ export class ProjectFeedController {
         }
     }
 }
-


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Scopes GET /feed/all to the user’s companies using x-company-id and JWT, adds company validation/filtering, and updates docs and examples accordingly.
> 
> - **Backend (ProjectFeedController)**:
>   - **Multi-tenant isolation**: Added `resolveUserCompanies` (JWT decode + `x-company-id`) to derive allowed `companyIds`.
>   - **Access control**: `GET /feed/all` now:
>     - Returns 403 if user has no companies.
>     - Validates `projectId` belongs to user companies; 404/403 on mismatch.
>     - Applies required filter `ServiceProject` by `company_id`/`Project.company_id ∈ companyIds`.
>     - Includes `companyIds` in response `filters`.
>   - **Imports**: Added `jsonwebtoken` usage.
> - **Docs (`docs/PROJECT_FEED.md`)**:
>   - Added multi-company isolation note and required `x-company-id` header for `GET /feed/all`.
>   - Updated curl examples to include `x-company-id`.
>   - Minor formatting tweak at file end.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a9f3dc8712b20bd17c80cab3b82c54c1b6d108b1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->