### PR TITLE
fix: bug de listagem de projetos para checkin

### DIFF
--- a/src/controllers/User/UserAttendanceController.ts
+++ b/src/controllers/User/UserAttendanceController.ts
@@ -659,8 +659,32 @@ export class UserAttendanceController {
                 return;
             }
 
-            // Determina a company_id (prioriza query param, depois user.company_id)
-            const finalCompanyId = (companyId as string) || user.company_id;
+            // Determina conjunto de empresas do usuário
+            const userCompanyIds = new Set<string>();
+            if (user.company_id) {
+                userCompanyIds.add(user.company_id);
+            }
+            user.companies.forEach((c) => {
+                if (c.companyId) {
+                    userCompanyIds.add(c.companyId);
+                }
+            });
+
+            // Se veio companyId na query, valida se pertence ao usuário
+            if (companyId) {
+                if (!userCompanyIds.has(companyId as string)) {
+                    res.status(403).json({ error: 'User does not belong to the requested company.' });
+                    return;
+                }
+                // Restringe ao companyId escolhido
+                userCompanyIds.clear();
+                userCompanyIds.add(companyId as string);
+            }
+
+            if (userCompanyIds.size === 0) {
+                res.status(403).json({ error: 'User has no associated company.' });
+                return;
+            }
 
             // Busca todos os serviços de projetos em andamento
             const serviceProjects = await prisma.serviceProject.findMany({
@@ -676,9 +700,9 @@ export class UserAttendanceController {
                         status_project: {
                             in: ["In Progress", "Final walkthrough"]
                         },
-                        // Filtra por empresa se especificado
-                        ...(finalCompanyId && {
-                            company_id: finalCompanyId
+                        // Filtra por empresas do usuário
+                        company_id: {
+                            in: Array.from(userCompanyIds)
                         })
                     },
                     // Busca por nome do serviço (opcional)

--- a/src/controllers/service/UserServiceProjectController.ts
+++ b/src/controllers/service/UserServiceProjectController.ts
@@ -523,8 +523,29 @@ export class UserServiceProjectController {
         return res.status(404).json({ error: 'User not found.' });
       }
 
-      // Determina a company_id
-      const finalCompanyId = (companyId as string) || user.company_id;
+      // Monta conjunto de empresas do usuário
+      const userCompanyIds = new Set<string>();
+      if (user.company_id) {
+        userCompanyIds.add(user.company_id);
+      }
+      user.companies.forEach((c) => {
+        if (c.companyId) {
+          userCompanyIds.add(c.companyId);
+        }
+      });
+
+      // Se companyId foi enviado, valida pertença
+      if (companyId) {
+        if (!userCompanyIds.has(companyId as string)) {
+          return res.status(403).json({ error: 'User does not belong to the requested company.' });
+        }
+        userCompanyIds.clear();
+        userCompanyIds.add(companyId as string);
+      }
+
+      if (userCompanyIds.size === 0) {
+        return res.status(403).json({ error: 'User has no associated company.' });
+      }
 
       // Busca todos os projetos em andamento
       const projects = await prisma.project.findMany({
@@ -533,10 +554,10 @@ export class UserServiceProjectController {
           status_project: {
             in: ["In Progress", "Final walkthrough"]
           },
-          // Filtra por empresa se especificado
-          ...(finalCompanyId && {
-            company_id: finalCompanyId
-          }),
+          // Filtra pelas empresas do usuário
+          company_id: {
+            in: Array.from(userCompanyIds)
+          },
           // Busca por endereço ou nome do cliente (opcional)
           ...(search && {
             OR: [


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Update listing endpoints to validate company membership and filter projects/services by the user’s associated companies, supporting multi-company users.
> 
> - **Backend (controllers)**
>   - **`UserAttendanceController.getAvailableProjectsForCheckIn`**:
>     - Replace single `companyId` logic with a set of user-associated companies.
>     - Validate optional `companyId` belongs to the user; error if not or if user has no companies.
>     - Filter `Project.company_id` using `in` over the user’s company set.
>   - **`UserServiceProjectController.getProjectsGroupedByAddress`**:
>     - Build and validate user company set (with optional `companyId` override).
>     - Restrict project query by `company_id in [user companies]`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1ad0abec244b3c4c62feffff65f10ff02cf17432. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->